### PR TITLE
Marines grab health and ammo in combat

### DIFF
--- a/evobot/src/bot_structs.h
+++ b/evobot/src/bot_structs.h
@@ -34,6 +34,7 @@ enum BotRole
 	BOT_ROLE_FIND_RESOURCES, // Will hunt for uncapped resource nodes and cap them. Will attack enemy resource towers
 	BOT_ROLE_SWEEPER,		 // Defensive role to protect infrastructure and build at base. Will patrol to keep outposts secure
 	BOT_ROLE_ASSAULT,		 // Will go to attack the hive and other alien structures
+	BOT_ROLE_BOMBARDIER,	 // Bot is armed with a GL and wants to wreck your shit
 
 	// Alien roles
 

--- a/evobot/src/bot_task.cpp
+++ b/evobot/src/bot_task.cpp
@@ -1039,6 +1039,7 @@ void BotProgressPickupTask(bot_t* pBot, bot_task* Task)
 		{
 			NSStructureType ItemType = UTIL_GetItemTypeFromEdict(Task->TaskTarget);
 
+			// Allows bots to drop their current primary weapon to pick up a new weapon
 			if (UTIL_DroppedItemIsPrimaryWeapon(ItemType))
 			{
 				NSWeapon CurrentPrimaryWeapon = GetBotMarinePrimaryWeapon(pBot);

--- a/evobot/src/bot_util.cpp
+++ b/evobot/src/bot_util.cpp
@@ -1121,7 +1121,21 @@ void BotAttackTarget(bot_t* pBot, edict_t* Target)
 
 void BotDropWeapon(bot_t* pBot)
 {
-	pBot->pEdict->v.impulse = IMPULSE_MARINE_DROP_WEAPON;
+	// Look straight ahead so we don't accidentally drop the weapon right at our feet and pick it up again instantly
+
+	Vector AimDir = UTIL_GetForwardVector(pBot->pEdict->v.v_angle);
+	Vector TargetAimDir = Vector(AimDir.x, AimDir.y, 0.0f);
+
+	Vector LookLoc = pBot->CurrentEyePosition + (TargetAimDir * 100.0f);
+
+	BotLookAt(pBot, LookLoc);
+
+	float AimDot = UTIL_GetDotProduct(AimDir, TargetAimDir);
+
+	if (AimDot >= 0.95f)
+	{
+		pBot->pEdict->v.impulse = IMPULSE_MARINE_DROP_WEAPON;
+	}
 }
 
 void BotReloadWeapons(bot_t* pBot)
@@ -2313,8 +2327,6 @@ void CustomThink(bot_t* pBot)
 			AlienThink(pBot);
 		}
 	}
-
-
 
 }
 


### PR DESCRIPTION
Marines will now grab nearby health and ammo packs while in combat if they are closer to them than the enemy