### PR TITLE
Implement Github CI (Actions) and Small AMBuild Script Update

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -1,0 +1,94 @@
+name: Build on Push
+
+# Workflow is triggered when a push is made to ANY branch or on pull request open/reopen!
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  build_main:
+    name: Build for ${{ matrix.os_short }} (${{ matrix.type }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - ubuntu-latest
+          - windows-latest
+        type: [ optimized, debug ]
+        include:
+          - os: ubuntu-latest
+            os_short: linux-latest
+            binary_ext: so
+            debug_ext: dbg
+            cc: clang-14
+            cxx: clang++-14
+
+          - os: ubuntu-20.04
+            os_short: linux-old
+            binary_ext: so
+            debug_ext: dbg
+            cc: clang-9
+            cxx: clang++-9
+
+          - os: windows-latest
+            os_short: windows-latest
+            binary_ext: dll
+            debug_ext: pdb
+            cc: not-used
+            cxx: not-used
+          - type: optimized
+            ambuild_params: "--enable-optimize --symbol-files"
+          - type: debug
+            ambuild_params: "--enable-debug"
+
+    steps:
+    - name: Install (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.cc }} ${{ matrix.cxx }} g++-multilib
+        echo "CC=${{ matrix.cc }}" >> $GITHUB_ENV
+        echo "CXX=${{ matrix.cxx }}" >> $GITHUB_ENV
+
+    - name: Setup MSBuild (Windows)
+      if: runner.os == 'Windows'
+      uses: microsoft/setup-msbuild@v1.3.1
+
+    - name: Setup Python
+      uses: actions/setup-python@v4.7.0
+      with:
+        python-version: '3.11'
+
+    - name: Setup ambuild
+      run: |
+        python -m pip install wheel
+        pip install git+https://github.com/alliedmodders/ambuild
+
+    - name: Fetch Evobot MM
+      uses: actions/checkout@v3.6.0
+      with:
+        path: evobot_mm
+
+    - name: Build Files
+      working-directory: evobot_mm
+      run: |
+        mkdir build
+        cd build
+        python3 ../configure.py ${{ matrix.ambuild_params }}
+        ambuild
+
+    - uses: benjlevesque/short-sha@v2.2
+      id: short-sha
+
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v3.1.2
+      with:
+        name: evobot_mm-${{ matrix.os_short }}-${{ matrix.type }}-${{ steps.short-sha.outputs.sha }}
+        path: |
+            evobot_mm/build/**/*.${{ matrix.binary_ext }}
+            evobot_mm/build/**/*.${{ matrix.debug_ext }}

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -82,7 +82,9 @@ if builder.options.optimize == '1':
   builder.cxx.defines += ['NDEBUG']
   if builder.cxx.target.platform == 'linux':
     # Linux optimization flags
-    builder.cxx.cflags += ['-O3']
+    # Was -O3 originally but -O3 is known to sometimes causes issues
+    # Until the code is profiled, use -O2 instead
+    builder.cxx.cflags += ['-O2']
   elif builder.cxx.target.platform == 'windows':
     # Windows optimization flags
     builder.cxx.cflags += ['/Ox', '/Zo']
@@ -102,7 +104,7 @@ if builder.options.debug == '1':
     # Windows debug link flags
     builder.cxx.linkflags += ['/NODEFAULTLIB:libcmt']
 
-# Handle --enable-static-lib and --enable-shared-li
+# Handle --enable-static-lib and --enable-shared-lib
 if builder.cxx.target.platform == 'linux':
   if builder.options.staticlib == '1':
     builder.cxx.linkflags += [


### PR DESCRIPTION
### Github CI (Actions)

- Workflow is triggered when a commit is pushed or when a pull request is open/reopen.
- Automatically builds evobot mm.
- Provides 6 build artifacts: Optimized and debug builds for Linux Latest (Ubuntu 22.04), Linux Old (Ubuntu 20.04), Windows Latest (Windows Server 2022).
- Linux Old mitigates the `version GLIBC_2.33 not found` issue by compiling evobot on an older OS version.

### AMBuildScript Changes

- Fixed small typo.
- Linux: Switched from -O3 to -O2. -O3 is known for having a few issues, evobot would need to be profiled in order to determine which optimization level is better. Until them, using -O2 should be fine.

