### PR TITLE
Fixed bots not dropping their weapon in 3.3 beta 5

### DIFF
--- a/evobot/src/bot_task.cpp
+++ b/evobot/src/bot_task.cpp
@@ -1047,7 +1047,7 @@ void BotProgressPickupTask(bot_t* pBot, bot_task* Task)
 			{
 				NSWeapon CurrentPrimaryWeapon = GetBotMarinePrimaryWeapon(pBot);
 
-				if (CurrentPrimaryWeapon != WEAPON_NONE && CurrentPrimaryWeapon != WEAPON_MARINE_MG)
+				if (CurrentPrimaryWeapon != WEAPON_NONE && CurrentPrimaryWeapon != UTIL_GetWeaponTypeFromEdict(Task->TaskTarget))
 				{
 					if (GetBotCurrentWeapon(pBot) != CurrentPrimaryWeapon)
 					{

--- a/evobot/src/meta_api.cpp
+++ b/evobot/src/meta_api.cpp
@@ -62,7 +62,7 @@ static META_FUNCTIONS gMetaFunctionTable = {
 plugin_info_t Plugin_info = {
 	META_INTERFACE_VERSION,	// ifvers
 	"Evobot",	// name
-	"1.1.0",	// version
+	"1.1.1",	// version
 	__DATE__,	// date
 	"Richard Greenlees",	// author
 	"https://github.com/RGreenlees/evobot_mm",	// url


### PR DESCRIPTION
* By default in 3.3 beta 5, you have to drop your MG to pick up another weapon. This meant bots could not pick up any new weapons and would get stuck. Bots now always drop their primary weapon even when not necessary (doesn't hurt either way)