### PR TITLE
Initialize the rng so chamber sequence can be more random

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _deps
 out/
 .vs/
 build/
+.vscode/

--- a/evobot/src/bot_config.cpp
+++ b/evobot/src/bot_config.cpp
@@ -565,7 +565,7 @@ void ParseConfigFile(bool bOverride)
                     int random = rand() % AvailableTechs.size();
                     HiveThreeTech = AvailableTechs[random];
 
-                    AvailableTechs.erase(std::remove(AvailableTechs.begin(), AvailableTechs.end(), HiveTwoTech), AvailableTechs.end());
+                    AvailableTechs.erase(std::remove(AvailableTechs.begin(), AvailableTechs.end(), HiveThreeTech), AvailableTechs.end());
                 }
 
 

--- a/evobot/src/dllapi.cpp
+++ b/evobot/src/dllapi.cpp
@@ -920,7 +920,7 @@ void ClientCommand(edict_t* pEntity)
 
 void GameDLLInit(void)
 {
-
+	srand((unsigned int)time(NULL));
 	GAME_Reset();
 	GAME_ClearClientList();
 	


### PR DESCRIPTION
Initializing the rng on GameDLLInit so that the order of evolution chambers is not always the same on startup if ChamberSequence is set to random in evobot.cfg.